### PR TITLE
Improve Community Overview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Plugin voor het aanmaken van de 'community'-taxonomie
 
 
 ## Current version:
-* 1.5.0 - Added Community Overview.
+* 1.5.1 - Added Community Term `url` property
 
 ## Version history
+* 1.5.1 - Added Community Term `url` property
 * 1.5.0 - Added Community Overview.
 * 1.4.6 - Added Community Detail Textblocks With Icon.
 * 1.4.5 - Added 3 community Visuals. Update visual name regex.

--- a/ictuwp-plugin-community-taxonomie.php
+++ b/ictuwp-plugin-community-taxonomie.php
@@ -85,6 +85,9 @@ if ( ! class_exists( 'ICTU_GC_community_taxonomy' ) ) :
 			// filter the breadcrumbs
 			add_filter( 'wpseo_breadcrumb_links', array( $this, 'fn_ictu_community_yoast_filter_breadcrumb' ) );
 
+			// check if the term has detail page attached
+			// add_action( 'template_redirect', array( $this, 'fn_ictu_community_check_redirect' ) );
+
 		}
 
 
@@ -243,6 +246,53 @@ if ( ! class_exists( 'ICTU_GC_community_taxonomy' ) ) :
 			return $links;
 
 		}
+
+
+		/**
+		 * Checks if the community term is linked to a page and redirect
+		 *
+		 * @return: {Function|null} wp_safe_redirect when possible
+		 *
+		 */
+		// public function fn_ictu_community_check_redirect() {
+		//
+		// 	if ( ! function_exists( 'get_field' ) ) {
+		// 		// we can't check if ACF is not active
+		// 		return;
+		// 	}
+		//
+		// 	if ( is_tax( GC_COMMUNITY_TAX ) ) {
+		//
+		// 		// check if the current term has a value for 'community_taxonomy_page'
+		// 		$pageid = get_field( 'community_taxonomy_page', GC_COMMUNITY_TAX . '_' . get_queried_object()->term_id );
+		// 		$page   = get_post( $pageid );
+		// 		if ( $page ) {
+		// 			// cool, a page is selected for this term
+		// 			// But is the page published?
+		// 			if ( 'publish' === $page->post_status ) {
+		// 				// good, it is published
+		// 				// let's redirect to that page
+		// 				wp_safe_redirect( get_permalink( $page->ID ) );
+		// 				exit;
+		//
+		// 			} else {
+		// 				// bad, we only want published pages
+		// 				$aargh = 'No published page attached to this community';
+		// 				if ( current_user_can( 'editor' ) ) {
+		// 					$editlink = get_edit_term_link( get_queried_object()->term_id, get_queried_object()->taxonomy );
+		// 					$aargh    .= '<a href="' . $editlink . '">Please choose a published page for this term.</a>';
+		// 				}
+		// 				die( $aargh );
+		// 			}
+		// 		} else {
+		// 			// no page is selected for this term
+		// 			// for now, do nothing
+		// 			die('do nothing?');
+		// 		}
+		// 	}
+		//
+		// }
+
 
 		/**
 		 * Retrieve a page that is the GC_COMMUNITY_TAX overview page. This

--- a/ictuwp-plugin-community-taxonomie.php
+++ b/ictuwp-plugin-community-taxonomie.php
@@ -8,8 +8,8 @@
  * Plugin Name:         ICTU / Gebruiker Centraal / Community taxonomie
  * Plugin URI:          https://github.com/ICTU/ictuwp-plugin-community-taxonomie
  * Description:         Plugin voor het aanmaken van de 'community'-taxonomie
- * Version:             1.5.0
- * Version description: Added Community Overview.
+ * Version:             1.5.1
+ * Version description: Added Community Term `url` property
  * Author:              David Hund
  * Author URI:          https://github.com/ICTU/ictuwp-plugin-community-taxonomie/
  * License:             GPL-3.0+

--- a/includes/community-taxonomy.php
+++ b/includes/community-taxonomy.php
@@ -126,8 +126,18 @@ function fn_ictu_community_get_community_terms( $community_name = null, $term_ar
 	$community_query    = is_array( $term_args ) ? $term_args : [
 		'taxonomy'   => $community_taxonomy,
 		// We also want Terms with NO linked content, in this case
-		'hide_empty' => false
+		'hide_empty' => false,
+		'orderby' => 'name',
+		'order' => 'ASC',
 	];
+
+	// NOTE:
+	// We want to order the Communities alphabetically
+	// based on their name. But we use the linked Page Title
+	// for the actual display. So really, we expect to order
+	// based on Term -> Page -> Title
+	// This is why we need to re-order the array
+	// in template-overview-communities.php
 
 	// Query specific term name
 	if ( ! empty( $community_name ) ) {

--- a/includes/community-taxonomy.php
+++ b/includes/community-taxonomy.php
@@ -166,6 +166,11 @@ function fn_ictu_community_get_community_terms( $community_name = null, $term_ar
 						$val = sprintf( '%s/images/%s', GC_COMMUNITY_TAX_ASSETS_PATH, $val );
 					}
 
+					// Add extra `url` property to Term if we have a linked Page
+					if( $key == 'community_taxonomy_page' && ! empty( $val ) ) {
+						$community_term->url = get_permalink( $val );
+					}
+
 					$community_term->$key = $val;
 				}
 			}

--- a/template-detail-communities.php
+++ b/template-detail-communities.php
@@ -88,7 +88,6 @@ if ( $current_community_term && ! is_wp_error( $current_community_term ) ) {
 		}
 
 		// If we have an extra Community Link
-		// we redirect to that URL instead of loading our detail template
 		if ( isset( $current_community_term_fields['community_taxonomy_link'] ) ) {
 			$context['community_link'] = $current_community_term_fields['community_taxonomy_link'];
 		}
@@ -111,7 +110,7 @@ if ( $current_community_term && ! is_wp_error( $current_community_term ) ) {
 	// text for 'inleiding' is taken from term description
 	// -----------------------------
 	// $timber_post->post_content = $current_community_term->description;
-	// Use Intro instead?!
+	// Use Excerpt instead?! Fall back to Term description if no Excerpt is set?
 	if ( empty( $context['intro'] ) ) {
 		$context['intro'] = wpautop( $current_community_term->description );
 	}

--- a/template-overview-communities.php
+++ b/template-overview-communities.php
@@ -19,91 +19,178 @@ $context['has_centered_intro'] = false;
  * Add communities (terms in Community taxonomy)
  */
 if ( function_exists( 'fn_ictu_community_get_community_terms' ) ) {
-	$context['items']    = [];
+	$community_items = [];
+
+	// Fill items (cards) for overview template
+
+	// NOTE [1]:
+	// fn_ictu_community_get_community_terms() returns
+	// an array of WP_Term objects, ordered by `name`.
+	//
+	// We want to order the Communities alphabetically
+	// based on their name. But we use the linked Page Title
+	// for the actual display. So really, we expect to order
+	// based on Term -> Page -> Title
+	// This is why we need to re-order the array
+	// here, after we've retrieved the page title
+	// in the loop below.
 
 	foreach ( fn_ictu_community_get_community_terms() as $community ) {
+
+		/**
+		 * $community is a WP_Term object
+		 * `term_id`                        {Integer} ID of Term
+		 * `name`                           {String}  Name of Term
+		 * `slug`                           {String}  Slug of Term
+		 * `description`                    {String}  Description of Term
+		 *
+		 * .. etc..
+		 *
+		 * ..BUT also with added ACF fields as properties!
+		 * (These could be empty)
+		 *
+		 * `community_taxonomy_colorscheme` {String}  Name of colorscheme, eg. "pink"
+		 * `community_taxonomy_visualm`     {Array}   Path to Community image
+		 * `community_taxonomy_link`        {Array}   Link object (title, url, target)
+		 * `community_taxonomy_page`        {Integer} ID of linked page
+		 */
 
 		$item = array(
 			// type, translates to card-type--{type}
 			'type'  => 'community',
-			// Title defaults to term name
+			// Title default: term name
 			'title' => $community->name,
-			// Descr defaults to term description
+			// Descr default: term description
 			'descr' => $community->description,
 		);
 
-		// Setup image to use in Card
+		// Setup properties to use for Card
+		$item_url = null;
 		$item_img = null;
 
 		// Linked Landingpage
-		if ( $community->community_taxonomy_page ) {
+		if ( empty( $community->community_taxonomy_page ) ) {
+			// We do NOT have a linked Page
+			// Abort *unless* we are viewing the page logged-in
+			// (in that case we show a warning)
+			if ( ! is_user_logged_in() ) {
+				// We do not show the card
+				continue;
+			} else {
+				// we show the card, but with a warning
+				$item['type']  = $item['type'] . ' card--has-warning';
+				$item['descr'] = sprintf(
+					'<a style="color:red" href="%s">%s</a>',
+					get_edit_term_link( $community->term_id, GC_COMMUNITY_TAX ),
+					_x('Deze card is verborgen totdat een pagina wordt gekoppeld aan deze Community!', 'Community overview: card warning', 'gctheme'),
+				);
+			}
+
+		} else {
 			// Fetch page from ID
 			$item_page = get_post( $community->community_taxonomy_page );
 			// If no ID or invalid, get_post _could_ return the *current* page..
 			if ( $item_page instanceof WP_Post ) {
 				$item_page_id = $item_page->ID;
 				// .. so check if it has the correct template
-				$item_page_template = get_post_meta( $item_page_id, '_wp_page_template', true );
-				if ( GC_COMMUNITY_TAX_DETAIL_TEMPLATE === $item_page_template ) {
+				$item_page_template    = get_post_meta( $item_page_id, '_wp_page_template', true );
+				// .. and if page is published
+				$item_page_status      = get_post_status( $item_page_id );
+
+				$item_page_template_ok = GC_COMMUNITY_TAX_DETAIL_TEMPLATE === $item_page_template;
+				$item_page_status_ok   = 'publish' === $item_page_status;
+
+				// Only continue if page has the correct template and is published
+				if ( $item_page_template_ok && $item_page_status_ok ) {
 					// Set Card image from page thumbnail
 					$item_img      = get_the_post_thumbnail_url( $item_page, 'image-16x9' ) ?: $item_img;
 					// Override: card Title from page link
 					$item['title'] = get_the_title( $item_page );
 					// Set Card url from page link
-					$item['url']   = get_page_link( $item_page );
-					// Override: card Description from page intro
+					$item_url      = get_page_link( $item_page );
+					// Override: card Description from:
 					// - the page excerpt (if set)
-					// - else: the term descr (set by default, could be empty)
-					// - else: the page 00 - intro
+					// - else: the page 00 - intro (if set)
+					// - else: the term descr
 					if ( $item_page->post_excerpt ) {
 						// only use the excerpt if the field is actually filled
 						$item['descr'] = get_the_excerpt( $item_page );
 					} elseif ( get_field( 'post_inleiding', $item_page ) ) {
 						$item['descr'] = get_field( 'post_inleiding', $item_page );
 					}
+					// No else needed for Term description as this was the default already..
+				} else {
+					// Not a proper page?
+					// Show warning *when* we are viewing the page logged-in
+					if ( ! is_user_logged_in() ) {
+						// We do not show the card
+						continue;
+					} else {
+						// we show the card, but with a warning
+						// (optionally check specific error with: $item_page_template_ok and $item_page_status_ok)
+						$item['type']  = $item['type'] . ' card--has-warning';
+						$item['descr'] = sprintf(
+							'<a style="color:red" href="%s">%s</a>',
+							get_edit_post_link( $item_page, 'edit' ),
+							_x('Deze card is verborgen totdat de pagina het  \'<em>[Community] detailpagina</em>\' template krijgt en gepubliceerd wordt!', 'Community overview: card warning', 'gctheme'),
+						);
+					}
 				}
 			}
 		}
 
-		// Image:
-		if ( $community->community_taxonomy_image ) {
-			$item_img = '<img src="' . $community->community_taxonomy_image['sizes']['image-16x9'] . '" alt=""/>';
-		}
-
 		// Visual
 		if ( $community->community_taxonomy_visual ) {
+			// Store the `visual` in the Card item
 			$item['visual'] = $community->community_taxonomy_visual;
-			// Use visual as featured image if no other image is set
+			// Use visual as card image only if no other image is set
 			if ( ! $item_img ) {
 				$item_img = $community->community_taxonomy_visual;
 			}
 		}
 
-		// Finally use preferred image for card
-		if ( $item_img ) {
-			$item['img'] = '<img src="' . $item_img . '" alt=""/>';
-		}
-
 		// Colorscheme:
 		if ( $community->community_taxonomy_colorscheme ) {
+			// Store the `palette` in the Card item
 			$item['palette'] = $community->community_taxonomy_colorscheme;
 			// Add extra class to card-type
 			$item['type'] = $item['type'] . ' palette--' . $item['palette'];
-
 		}
 
 		// Link: link to subsite?
 		if ( $community->community_taxonomy_link ) {
-			// We do not yet link to a subsite
-			// but _always_ refer to the landing page first..
-			// $item['url'] = $community->community_taxonomy_link['url'];
+			// Store the `link` in the Card item
+			// NOTE: this is NOT the Card URL.
+			// We do not link to a subsite directly,
+			// but _always_ refer to the landing page (URL) first..
 			$item['link'] = $community->community_taxonomy_link;
 		}
 
+		// Use preferred image for card
+		if ( $item_img ) {
+			$item['img'] = '<img src="' . $item_img . '" alt=""/>';
+		}
 
-		$context['items'][] = $item;
+		// Use preferred URL for card
+		if ( $item_url ) {
+			$item['url'] = $item_url;
+		}
+
+		// Fill all items with new item
+		$community_items[] = $item;
 
 	}
+
+	// NOTE [1]:
+	// Re-order the Communities alphabetically
+	// based on their linked Page Title.
+	// They were originally ordered by Term name
+	usort( $community_items, function( $a, $b ) {
+		return strcmp( strtoupper( $a['title'] ), strtoupper( $b['title'] ) );
+	} );
+
+	$context['items'] = $community_items;
+
 }
 
 // Enqueue page-specific JS (checkbox filters)


### PR DESCRIPTION
- Do not show cards without linked (and valid) Page
- .. Show warning for logged in users instead
- Do not link cards with no (valid) URL
- Sort cards alphabetically, based on _page_ title (instead of Term name)
- Use proper 'cascade' for Card description
- Use `url` property on Term to allow linking to coupled landingpage
- **WIP** Try and redirect Community Archives to landingpage