### PR TITLE
v1.5.3 - Reset `$template` for Community tax. Term archives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Plugin voor het aanmaken van de 'community'-taxonomie
 
 
 ## Current version:
-* 1.5.2 - Make title for tags component translatable. 
+* 1.5.3 - Reset `$template` for Community tax. Term archives.
 
 ## Version history
-* 1.5.2 - Make title for tags component translatable. 
+* 1.5.3 - Reset `$template` for Community tax. Term archives.
+* 1.5.2 - Make title for tags component translatable.
 * 1.5.1 - Added Community Term `url` property
 * 1.5.0 - Added Community Overview.
 * 1.4.6 - Added Community Detail Textblocks With Icon.

--- a/ictuwp-plugin-community-taxonomie.php
+++ b/ictuwp-plugin-community-taxonomie.php
@@ -8,8 +8,8 @@
  * Plugin Name:         ICTU / Gebruiker Centraal / Community taxonomie
  * Plugin URI:          https://github.com/ICTU/ictuwp-plugin-community-taxonomie
  * Description:         Plugin voor het aanmaken van de 'community'-taxonomie
- * Version:             1.5.2
- * Version description: Make title for tags component translatable. 
+ * Version:             1.5.3
+ * Version description: Reset `$template` for Community tax. Term archives.
  * Author:              David Hund
  * Author URI:          https://github.com/ICTU/ictuwp-plugin-community-taxonomie/
  * License:             GPL-3.0+
@@ -119,6 +119,18 @@ if ( ! class_exists( 'ICTU_GC_community_taxonomy' ) ) :
 		 *
 		 */
 		public function fn_ictu_community_append_template_locations( $template ) {
+
+			// For SOME reason, we still get a $post object,
+			// even if we are on a taxonomy archive page..
+			// This messes with the template selection, so we need to check for that
+			// and use the default archive template
+			// @TODO: investigate/improve this
+			if ( is_tax( GC_COMMUNITY_TAX ) ) {
+				// $term = get_queried_object();
+				return $template;
+			}
+
+			// Not a taxonomy archive page, so continue as before...
 
 			// Get global post
 			global $post;


### PR DESCRIPTION
Om e.o.a. reden gaf https://gebruikercentraal.test/community/community-cx/ bij mij een 'archief' terug in de vorm van het Community detailpagina template...  zoals op https://gebruikercentraal.test/communitys/community-cx/

(zie het subtiele verschil tussen `/community/<slug>` (Community taxonomy slug) en  `/communitys/<slug>` (slug van hoofdpagina waaronder community _pagina's_ vallen)

Waarom dit gebeurt weet ik niet.

Deze PR 'fixed' het door in `fn_ictu_community_append_template_locations()` keihard te checken of we te maken hebben met een Taxonomy archief en — in dat geval — direct het standaard `$template` terug te geven...

Uitkomst: https://gebruikercentraal.test/community/community-cx/  toont nu (correct) een _archief_ van content waaraan de 'Community CX' term is gekoppeld (in plaats van een halfbakken Community Detail template)